### PR TITLE
Add pwsh option to work with powershell 6+

### DIFF
--- a/powershell.js
+++ b/powershell.js
@@ -7,7 +7,8 @@ module.exports = function(RED) {
         RED.nodes.createNode(this, config);
         let ps = new shell({
             executionPolicy: 'Bypass',
-            noProfile: true
+            noProfile: true,
+            pwsh: true
         });
 
         this.on('input', function(msg) {


### PR DESCRIPTION
This option is necessary for working on linux as well, as in _powershell core v6+_ the executable name has been changed by Microsoft from `powershell` to `pwsh`.